### PR TITLE
Wire texture filtering into workflow validation

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -208,6 +208,7 @@ jobs:
             tools/tests/renderer_classic_deform_domain.py \
             tools/tests/renderer_msaa_cvar_safety.py \
             tools/tests/renderer_picmip_policy.py \
+            tools/tests/renderer_texture_filter.py \
             tools/tests/renderer_player_visibility.py \
             tools/tests/renderer_screenshot_readback.py \
             tools/tests/renderer_supersampling_safety.py \
@@ -361,6 +362,7 @@ jobs:
           python tools/tests/renderer_classic_deform_domain.py
           python tools/tests/renderer_msaa_cvar_safety.py
           python tools/tests/renderer_picmip_policy.py
+          python tools/tests/renderer_texture_filter.py
           python tools/tests/renderer_player_visibility.py
           python tools/tests/renderer_screenshot_readback.py
           python tools/tests/renderer_supersampling_safety.py

--- a/.github/workflows/push-verification.yml
+++ b/.github/workflows/push-verification.yml
@@ -208,6 +208,7 @@ jobs:
             tools/tests/renderer_classic_deform_domain.py \
             tools/tests/renderer_msaa_cvar_safety.py \
             tools/tests/renderer_picmip_policy.py \
+            tools/tests/renderer_texture_filter.py \
             tools/tests/renderer_player_visibility.py \
             tools/tests/renderer_screenshot_readback.py \
             tools/tests/renderer_supersampling_safety.py \
@@ -361,6 +362,7 @@ jobs:
           python tools/tests/renderer_classic_deform_domain.py
           python tools/tests/renderer_msaa_cvar_safety.py
           python tools/tests/renderer_picmip_policy.py
+          python tools/tests/renderer_texture_filter.py
           python tools/tests/renderer_player_visibility.py
           python tools/tests/renderer_screenshot_readback.py
           python tools/tests/renderer_supersampling_safety.py


### PR DESCRIPTION
## Summary

Add the texture-filter contract introduced with #121 to both lightweight workflow gates:

- Python syntax/import compilation
- direct contract execution

This restores the repository-wide invariant enforced by `validation_hardening.py`: every non-runtime test under `tools/tests/` must be represented in local, commit, and push validation.

## Validation

- `renderer_texture_filter.py`
- `validation_hardening.py`
- actionlint on both changed workflows
- `git diff --check`

Follow-up to #130.