### PR TITLE
Honor custom GameLibs path in settings validation

### DIFF
--- a/tools/tests/settings_menu_coverage.py
+++ b/tools/tests/settings_menu_coverage.py
@@ -3,12 +3,15 @@
 
 from collections import defaultdict
 import json
+import os
 from pathlib import Path
 import re
 
 
 ROOT = Path(__file__).resolve().parents[2]
-GAME_LIBS = ROOT.parent / "openQ4-game"
+GAME_LIBS = Path(
+    os.environ.get("OPENQ4_GAMELIBS_REPO", ROOT.parent / "openQ4-game")
+).resolve()
 
 
 def read(path: Path) -> str:

--- a/tools/tests/validation_hardening.py
+++ b/tools/tests/validation_hardening.py
@@ -585,6 +585,9 @@ def validate_python_test_failure_aggregation() -> None:
 
 def validate_validation_wiring() -> None:
     validator = (ROOT / "tools" / "validation" / "openq4_validate.py").read_text(encoding="utf-8")
+    settings_coverage = (ROOT / "tools" / "tests" / "settings_menu_coverage.py").read_text(
+        encoding="utf-8"
+    )
     push = (ROOT / ".github" / "workflows" / "push-verification.yml").read_text(encoding="utf-8")
     commit = (ROOT / ".github" / "workflows" / "commit-validation.yml").read_text(encoding="utf-8")
     release_notes = (ROOT / "docs/dev" / "release-completion.md").read_text(encoding="utf-8")
@@ -617,6 +620,9 @@ def validate_validation_wiring() -> None:
     ):
         if "validation_hardening.py" not in text:
             raise AssertionError(f"validation_hardening.py is not wired into {context}")
+
+    if 'os.environ.get("OPENQ4_GAMELIBS_REPO"' not in settings_coverage:
+        raise AssertionError("settings menu coverage ignores the configured GameLibs repository")
 
     # Runtime drivers that need a built target package or retail assets; their
     # static contracts are wired into lightweight local validation instead.


### PR DESCRIPTION
## Summary
- make `settings_menu_coverage.py` honor `OPENQ4_GAMELIBS_REPO`, matching the validation runner and the rest of the GameLib-aware tests
- resolve the configured checkout before reading SP/MP cvar sources
- pin the environment-variable contract in validation hardening coverage

## Why
The test silently hardcoded the sibling `../openQ4-game` checkout. A caller using `openq4_validate.py --game-libs-repo ...` could therefore validate settings against the wrong GameLib revision even though the runner printed and exported the requested path.

## Validation
- `settings_menu_coverage.py` passed against the workflow-pinned openQ4-game commit through a non-default `.tmp` worktree
- an import probe confirmed a distinct custom path is selected before any source reads
- `validation_hardening.py`
- `py_compile`
- `git diff --check`