### PR TITLE
Prepare openQ4 0.13.0 release notes

### DIFF
--- a/docs/dev/releases/v0.13.0.md
+++ b/docs/dev/releases/v0.13.0.md
@@ -1,0 +1,49 @@
+# openQ4 0.13.0
+
+## Highlights
+
+- **High-refresh gameplay is much smoother while game logic stays at its original rate.** The camera, first-person weapon, skeletal animation, projectiles, moving world objects, lights, and effects can now present an interpolated pose between authoritative game ticks. Zoom markings and joint-bound effects follow the pose actually shown.
+- **Experimental rendering has a broader, safer foundation.** OpenGL and Vulkan now share sealed contracts for classic materials, GUIs, interactions, fog, subviews, deforms, and post effects. Optional temporal AA/upscaling, dynamic resolution, GPU skinning, PBR materials, reflections, volumetrics, and indirect-light previews remain default-off and retain complete fallback paths.
+- **Vulkan shadows are more complete and easier to diagnose.** Shadow-mapped lights can replace eligible stencil work, combine cached static and dynamic casters, reuse fitted cascades, expose receiver/debug views, and report non-blocking GPU timings without losing direct lighting when a shadow allocation fails.
+- **Complex levels load and settle faster.** The `airdefense1` opening avoids presentation work for cinematic frames that are never displayed and skips bake-only light-grid setup during ordinary play. A guarded repeat-load cache can be enabled for evaluation, while the classic source path remains the default.
+- **Saving and restoring fail safely.** Unset or invalid GUI animation values can no longer abort an otherwise valid save, malformed GUI and auxiliary data is rejected before partial state reaches the renderer, and incompatible old saves are refused before the active level is unloaded.
+- **Internet multiplayer is safer and easier to enter.** Network parsers now reject truncated state at explicit boundaries, remote administration avoids plaintext passwords by default, pure play keeps asset checks without accepting executable code from servers, and connecting opens a compact Quake 4-styled join card over the live map.
+- **Liquids and effects feel more complete.** Projectiles and hitscan shots cross liquid surfaces with matching splashes, sounds, and underwater trails; water jumping is reliable; slime, lava, and drowning have distinct feedback; and soft particles now reduce hard intersections between smoke and solid geometry.
+- **Everyday controls and presentation received focused polish.** Controller menu traversal no longer fights stale mouse focus, scalable menu text selects a sharper source atlas on modern displays, material texture filtering is configurable again, and light-grid preloading is available in Display settings.
+- **Platform and tool reliability improved.** macOS packages bundle OpenAL Soft to prevent long-session audio exhaustion, Linux accepts legitimate repeated-dot save paths, staged packages reject case-colliding files, and `dmap` once again compiles `func_group` geometry correctly.
+
+## Upgrade Notes
+
+- Replace the complete openQ4 package for your platform. Keep the engine, renderer modules, `game_sp`, `game_mp`, and bundled `baseoq4` data from the same 0.13.0 package.
+- Retail Quake 4 assets are still required. Point openQ4 at a complete installation, including the unsuffixed language archive such as `zpak_english.pk4`.
+- Existing settings remain valid. Soft particles now default to on for new configurations; an existing archived `r_softParticles` value is preserved.
+- OpenGL remains the default and recommended renderer. Vulkan remains experimental and opt-in with `r_renderApi vulkan`, applied after restart.
+- Temporal AA, dynamic resolution, GPU skinning, modern shared-renderer domains, PBR lighting, screen-space effects, and repeat-load caching remain experimental and default-off. `r_rendererModernQuality 0` and `com_levelLoadModernization 0` retain the established rendering and loading paths.
+- Saves from unsupported older development formats are rejected before unloading the current map. Finish an affected campaign using the build that wrote it, and keep backups of important saves before upgrading.
+- macOS users should replace the complete package to receive the bundled OpenAL Soft runtime. macOS support remains experimental, and Linux ARM64 packages remain preview-tier.
+- Server operators should review the updated remote-console, pure-server, package-download, and malformed-packet behavior before replacing a public server.
+
+## Change Log
+
+- Added presentation-only interpolation for eligible single-player actors, first-person weapons, movers, projectiles, lights, and effects while preserving authoritative simulation, collision, networking, demos, and save behavior.
+- Added default-off native-history TAA/TAAU and bounded delayed-GPU-time dynamic resolution on OpenGL and Vulkan, with native-resolution HUD, menu, console, screenshot, and save-preview output.
+- Added default-off exact four-weight GPU skinning for supported MD5 and MD5R models, with CPU-owned collision, traces, decals, overlays, and stencil-shadow data.
+- Added guarded PBR materials, OpenGL specular probes and clustered decals, plus bounded OpenGL/Vulkan volumetric, SSR, and SSGI preview paths.
+- Added shared, atomic renderer contracts for eligible GUI, in-world GUI, world ambient, interaction, fog/blend, cinematic/post, special-frame, subview, and material-deform work.
+- Expanded Vulkan shadow-map ownership, static/dynamic caster composition, fitted cascade caching, receiver diagnostics, debug overlays, and timestamp-query timing.
+- Improved shadow-map caster coverage and contact quality for open, thin, and sealed stock geometry while preserving stencil fallback ownership.
+- Added backend-neutral whole-frame CPU/GPU measurement and replayable per-map renderer budget contracts.
+- Reduced `airdefense1` cinematic and light-grid startup work, and added a guarded exact-source repeat-load cache backed by bounded background jobs and transactional model/world/collision data.
+- Fixed animated-model traces so stable surface IDs, reordered snapshots, omitted meshes, and generated backfaces resolve to the correct MD5/MD5R joint instead of terminating the level.
+- Prevented non-finite or uninitialized cosmetic GUI values from aborting saves, and strengthened preflight checks for incompatible, truncated, or corrupt save data.
+- Hardened Base64, lexer, GUI timeline/restore, render-demo, decal, CVar dictionary, user-command, snapshot, projectile, and hit-scan decoding against malformed input.
+- Restored pure multiplayer asset enforcement without allowing package negotiation to install or launch executable code, and replaced plaintext-by-default remote-console authentication with bounded `rcon2`.
+- Added the compact multiplayer join card, restored the stock F1/F2/F3/F6/F7 match actions, improved snapshot/effect rate handling, and prevented clients from authoring the clock used for lag-compensated hit judgment.
+- Added complete liquid crossing, underwater trail, water-jump, sound, obituary, and developer-lab behavior using bundled openQ4 content and stock media.
+- Enabled soft particles by default while excluding depth-hacked and unsupported effects from the fade.
+- Restored all six Quake 4 material texture-filter modes on OpenGL and Vulkan with immediate sampler refresh.
+- Improved controller menu focus, high-resolution font-atlas selection, machinegun zoom alignment, single-player pause-menu responsiveness, and the Display setting for optional light-grid preloading.
+- Bundled checksum-pinned OpenAL Soft in macOS packages and made backend allocation/upload exhaustion fail gracefully.
+- Fixed SDL swap-interval updates after temporary context detachment, Linux save paths containing legitimate repeated dots, and case-insensitive package path collisions.
+- Restored `dmap` handling of `func_group` geometry, initialized geometry-tool surface allocation, and accepted generated AAS 1.08 face settings.
+- Added contributing and community-conduct documentation and packaged the relevant project guidance with releases.


### PR DESCRIPTION
Adds the curated player-facing notes consumed by the manual release workflow for `v0.13.0`.

The notes cover the major rendering, loading, save, multiplayer, liquid, input, platform, and tooling changes since `v0.12.0`, with explicit upgrade guidance and conservative labels for experimental features.

Validation:

- generated the exact workflow changelog body and confirmed it selected `docs/dev/releases/v0.13.0.md`
- `python tools/tests/release_tooling_safety.py`
- `python tools/tests/docs_link_integrity.py`
- `python tools/tests/source_charset_integrity.py`
- `git diff --check`

The subsequent manual release dispatch will use `version_override=0.13.0` and `draft=true`. Draft releases skip the manual Discord job, do not trigger the published-release Discord workflow, and are rejected by the announcer itself if presented directly.
