### PR TITLE
Fix macOS release OpenAL dependency audit

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1635,6 +1635,7 @@ jobs:
           sp_module="${module_dir}/game-sp_${{ matrix.binary_arch }}.dylib"
           mp_module="${module_dir}/game-mp_${{ matrix.binary_arch }}.dylib"
           renderer_module="${module_dir}/renderer-vk_${{ matrix.binary_arch }}.dylib"
+          openal_runtime="${module_dir}/libopenal.1.dylib"
 
           if [ ! -f "${app_plist}" ]; then
             echo "Missing macOS app Info.plist: ${app_plist}"
@@ -1853,6 +1854,12 @@ jobs:
                 case "${dependency}" in
                   /System/Library/*|/usr/lib/*)
                     ;;
+                  @rpath/libopenal.1.dylib)
+                    if [ ! -f "${openal_runtime}" ]; then
+                      echo "macOS binary requires the bundled OpenAL Soft runtime, but it is missing: ${openal_runtime}"
+                      exit 1
+                    fi
+                    ;;
                   *)
                     echo "macOS binary has unbundled non-system dependency: ${binary} (${macho_arch}) -> ${dependency}"
                     exit 1
@@ -1861,7 +1868,7 @@ jobs:
               done
             done
           }
-          for binary in "${app_exec}" "${client_binary}" "${dedicated_binary}" "${sp_module}" "${mp_module}" "${renderer_module}"; do
+          for binary in "${app_exec}" "${client_binary}" "${dedicated_binary}" "${sp_module}" "${mp_module}" "${renderer_module}" "${openal_runtime}"; do
             check_macos_binary_architecture "${binary}"
             check_macos_binary_dependencies "${binary}"
             check_macos_codesignature "${binary}"
@@ -1883,6 +1890,7 @@ jobs:
           check_macos_install_name "${sp_module}" "@loader_path/game-sp_${{ matrix.binary_arch }}.dylib"
           check_macos_install_name "${mp_module}" "@loader_path/game-mp_${{ matrix.binary_arch }}.dylib"
           check_macos_install_name "${renderer_module}" "@loader_path/renderer-vk_${{ matrix.binary_arch }}.dylib"
+          check_macos_install_name "${openal_runtime}" "@rpath/libopenal.1.dylib"
           check_plist_value() {
             key="$1"
             expected="$2"

--- a/docs/dev/release-completion.md
+++ b/docs/dev/release-completion.md
@@ -1,5 +1,6 @@
 # openQ4 Release Completion List
 
+- [x] Manual macOS release validation now recognizes the package's exact `@rpath/libopenal.1.dylib` dependency only when the pinned runtime exists inside `openQ4.app/Contents/Frameworks`. The redundant workflow audit also verifies that runtime's architecture, system-only dependencies, code signature, and install name before accepting either experimental macOS package.
 - [x] Controller menu navigation now clears stale mouse highlights, hides the idle pointer, and traverses visible controls in both directions. Moving or clicking the mouse restores pointer control.
 - [x] Players can reduce light-grid upload stutter through Settings > Display > Post FX > Preload Light Grids. The option applies on the next map load and explains its loading-time and video-memory costs; the default remains off.
 

--- a/docs/dev/releases/v0.13.0.md
+++ b/docs/dev/releases/v0.13.0.md
@@ -44,6 +44,7 @@
 - Restored all six Quake 4 material texture-filter modes on OpenGL and Vulkan with immediate sampler refresh.
 - Improved controller menu focus, high-resolution font-atlas selection, machinegun zoom alignment, single-player pause-menu responsiveness, and the Display setting for optional light-grid preloading.
 - Bundled checksum-pinned OpenAL Soft in macOS packages and made backend allocation/upload exhaustion fail gracefully.
+- Fixed the manual macOS release audit so the exact bundled OpenAL Soft `@rpath` dependency is accepted only after its architecture, dependencies, signature, and install name pass validation.
 - Fixed SDL swap-interval updates after temporary context detachment, Linux save paths containing legitimate repeated dots, and case-insensitive package path collisions.
 - Restored `dmap` handling of `func_group` geometry, initialized geometry-tool surface allocation, and accepted generated AAS 1.08 face settings.
 - Added contributing and community-conduct documentation and packaged the relevant project guidance with releases.

--- a/tools/tests/macos_openal_provider_policy.py
+++ b/tools/tests/macos_openal_provider_policy.py
@@ -107,6 +107,14 @@ def validate_release_workflows() -> None:
 
     require(manual, '"platform": "macos"', "manual release macOS matrix")
     require(manual, '"macos_openal_provider": "system"', "manual release OpenAL Soft pin")
+    for token in (
+        'openal_runtime="${module_dir}/libopenal.1.dylib"',
+        "@rpath/libopenal.1.dylib)",
+        'if [ ! -f "${openal_runtime}" ]; then',
+        '"${renderer_module}" "${openal_runtime}"',
+        'check_macos_install_name "${openal_runtime}" "@rpath/libopenal.1.dylib"',
+    ):
+        require(manual, token, "manual release bundled OpenAL dependency audit")
     for source, context in (
         (manual, "manual release workflow"),
         (commit, "commit validation workflow"),


### PR DESCRIPTION
The first `v0.13.0` draft build exposed a release-blocking mismatch in the redundant macOS Mach-O audit. The package correctly embedded OpenAL Soft at `openQ4.app/Contents/Frameworks/libopenal.1.dylib`, but the workflow rejected the client's exact `@rpath/libopenal.1.dylib` reference as an unbundled dependency.

This allows only that exact `@rpath` reference and only when the expected runtime exists. The embedded library is added to the same architecture, dependency, code-signature, and install-name checks as the app and modules. Arbitrary `@rpath` and other non-system dependencies remain rejected.

Validation:

- `python tools/tests/macos_openal_provider_policy.py`
- `python tools/tests/release_tooling_safety.py`
- `python tools/tests/macos_metal_bridge.py`
- `python tools/tests/source_charset_integrity.py`
- `python -m py_compile tools/tests/macos_openal_provider_policy.py`
- `python tools/validation/openq4_validate.py macos-static --dry-run`
- `git diff --check`

The failed draft workflow was cancelled before publication. No release or Discord announcement was created.
